### PR TITLE
Experimental @bind support [Discussion]

### DIFF
--- a/sample/Test.hx
+++ b/sample/Test.hx
@@ -36,6 +36,36 @@ class SyntaxTest extends Components.BaseComponent {
 
 }
 
+class BindingTest extends Components.BaseComponent {
+
+	static var SRC = <binding-test>
+		<text text={@bind(myLabel) labelPrefix + " " + myText + "!"}/>
+	</binding-test>
+
+	var labelPrefix = "Hello";
+	var labelText(default, set) = "My Placeholder";
+	var binding:Void->Void;
+
+	public function new(?parent) {
+		super(parent);
+		var arr = [1,2,3];
+		initComponent();
+		labelText = "My Label";
+	}
+	function set_labelText(v) {
+		labelText = v;
+		if(binding != null) binding();
+		return v;
+	}
+	function myText(cb:Void->Void):String {
+		binding = cb;
+		return labelText;
+	}
+	function registerBind(cb, name) {
+		trace("Registered binding of name: "+name);
+	}
+}
+
 class Test {
 
 	public static var exampleText = "Hello World";
@@ -59,6 +89,10 @@ class Test {
 		trace(o.sub.paddingLeft); // 60
 
 		trace(o.sub.maxWidth); // null
+
+
+		var o = new BindingTest();
+		trace( cast(o.getChildren()[0],Components.TextComponent).text );
 
 	}
 

--- a/sample/Test.hx
+++ b/sample/Test.hx
@@ -36,36 +36,6 @@ class SyntaxTest extends Components.BaseComponent {
 
 }
 
-class BindingTest extends Components.BaseComponent {
-
-	static var SRC = <binding-test>
-		<text text={@bind(myLabel) labelPrefix + " " + myText + "!"}/>
-	</binding-test>
-
-	var labelPrefix = "Hello";
-	var labelText(default, set) = "My Placeholder";
-	var binding:Void->Void;
-
-	public function new(?parent) {
-		super(parent);
-		var arr = [1,2,3];
-		initComponent();
-		labelText = "My Label";
-	}
-	function set_labelText(v) {
-		labelText = v;
-		if(binding != null) binding();
-		return v;
-	}
-	function myText(cb:Void->Void):String {
-		binding = cb;
-		return labelText;
-	}
-	function registerBind(cb, name) {
-		trace("Registered binding of name: "+name);
-	}
-}
-
 class Test {
 
 	public static var exampleText = "Hello World";
@@ -89,10 +59,6 @@ class Test {
 		trace(o.sub.paddingLeft); // 60
 
 		trace(o.sub.maxWidth); // null
-
-
-		var o = new BindingTest();
-		trace( cast(o.getChildren()[0],Components.TextComponent).text );
 
 	}
 


### PR DESCRIPTION
This PR implements a first draft of a potential built-in data-binding bridge for Domkit components, as mentioned in: https://github.com/HeapsIO/domkit/issues/20

**EDIT**:

I updated the the implementation to do only the following:

1. Detect all node attributes with code containing `@bind`
2. Find all identifiers and field accessors within these expressions
3. Extract those and wrap each one in a `domkit.Macro.bindVar()` macro call. This is done in order to delay replacement to the stage, where full type information is available.
4. Wrap assignment to the Domkit component's property in a callback (`__onVarChanged`)
5. Pass all expressions from `bindVar` to a dynamic function `processBind` for user land to implement.

Users will have to implement `domkit.Macro.processBind` and pass back an expression doing the actual data-binding logic. This logic calls `__onVarChanged()` in order to trigger a re-evaluation of the entire attribute expression and have the new value be assigned to the component's property.

**Pros**

- Allows for values to be associated with `@bind` expressions and trigger a re-assignment. This is more in-line with common event driven data-models. Unlike per-expression based registration/callbacks as `registerCheckRebuild` does.
- Makes no assumption on how the actual data-binding looks like and leaves this up to users to implement

Please feel free to make suggestions.