### PR TITLE
adds disabled pseudo-class

### DIFF
--- a/domkit/CssParser.hx
+++ b/domkit/CssParser.hx
@@ -35,9 +35,10 @@ enum abstract PseudoClass(Int) {
 	var Odd = 8;
 	var Even = 16;
 	var Active = 32;
+	var Disabled = 64;
 
 	// set for some flags requiring children checks
-	var NeedChildren = 64;
+	var NeedChildren = 128;
 
 	inline function new(v:Int) {
 		this = v;
@@ -452,6 +453,8 @@ class CssParser {
 						switch( i ) {
 						case "hover":
 							c.pseudoClasses |= HOver;
+						case "disabled":
+							c.pseudoClasses |= Disabled;
 						case "first-child":
 							c.pseudoClasses |= FirstChild;
 							c.pseudoClasses |= NeedChildren;

--- a/domkit/CssStyle.hx
+++ b/domkit/CssStyle.hx
@@ -366,6 +366,8 @@ class CssStyle {
 				return false;
 			if( c.pseudoClasses.has(Active) && !e.active )
 				return false;
+			if( c.pseudoClasses.has(Disabled) && !e.disabled )
+				return false;
 			if( c.pseudoClasses.has(NeedChildren) ) {
 				var parent = e.parent;
 				if( parent == null )

--- a/domkit/Properties.hx
+++ b/domkit/Properties.hx
@@ -140,7 +140,6 @@ class Properties<T:Model<T>> {
 		return disabled = b;
 	}
 
-
 	function initStyle( p : String, value : Dynamic ) {
 		style.push({ p : Property.get(p), value : value });
 		needRefresh();

--- a/domkit/Properties.hx
+++ b/domkit/Properties.hx
@@ -24,6 +24,7 @@ class Properties<T:Model<T>> {
 	public var component(default,null) : Component<T,Dynamic>;
 	public var hover(default,set) : Bool = false;
 	public var active(default,set) : Bool = false;
+	public var disabled(default,set) : Bool = false;
 	public var parent(get,never) : Properties<T>;
 	public var contentRoot(default,null) : Model<T>;
 
@@ -132,6 +133,13 @@ class Properties<T:Model<T>> {
 		needRefresh();
 		return active = b;
 	}
+
+	function set_disabled(b) {
+		if( disabled == b ) return b;
+		needRefresh();
+		return disabled = b;
+	}
+
 
 	function initStyle( p : String, value : Dynamic ) {
 		style.push({ p : Property.get(p), value : value });


### PR DESCRIPTION
Domkit has :active and :hover but no :disabled which is useful for "button like" or clickable elements. :disabled is also heavily used in css so it might make sense to add it here as well.