### PR TITLE
Add :focus pseudoclass

### DIFF
--- a/domkit/CssParser.hx
+++ b/domkit/CssParser.hx
@@ -29,7 +29,7 @@ enum Token {
 enum abstract PseudoClass(Int) {
 
 	var None = 0;
-	var HOver = 1;
+	var Hover = 1;
 	var FirstChild = 2;
 	var LastChild = 4;
 	var Odd = 8;
@@ -453,7 +453,7 @@ class CssParser {
 					case TDblDot:
 						switch( i ) {
 						case "hover":
-							c.pseudoClasses |= HOver;
+							c.pseudoClasses |= Hover;
 						case "disabled":
 							c.pseudoClasses |= Disabled;
 						case "first-child":

--- a/domkit/CssParser.hx
+++ b/domkit/CssParser.hx
@@ -36,9 +36,10 @@ enum abstract PseudoClass(Int) {
 	var Even = 16;
 	var Active = 32;
 	var Disabled = 64;
+	var Focus = 128;
 
 	// set for some flags requiring children checks
-	var NeedChildren = 128;
+	var NeedChildren = 256;
 
 	inline function new(v:Int) {
 		this = v;
@@ -469,6 +470,8 @@ class CssParser {
 							c.pseudoClasses |= NeedChildren;
 						case "active":
 							c.pseudoClasses |= Active;
+						case "focus":
+							c.pseudoClasses |= Focus;
 						default:
 							throw new Error("Unknown selector "+i, pos - i.length - 1, pos);
 						}

--- a/domkit/CssStyle.hx
+++ b/domkit/CssStyle.hx
@@ -605,7 +605,7 @@ class CssStyle {
 		if( c.id != null && c.id != e.id )
 			return false;
 		if( c.pseudoClasses != None ) {
-			if( c.pseudoClasses.has(HOver) && !e.hover )
+			if( c.pseudoClasses.has(Hover) && !e.hover )
 				return false;
 			if( c.pseudoClasses.has(Active) && !e.active )
 				return false;

--- a/domkit/CssStyle.hx
+++ b/domkit/CssStyle.hx
@@ -611,6 +611,8 @@ class CssStyle {
 				return false;
 			if( c.pseudoClasses.has(Disabled) && !e.disabled )
 				return false;
+			if( c.pseudoClasses.has(Focus) && !e.focus )
+				return false;
 			if( c.pseudoClasses.has(NeedChildren) ) {
 				var parent = e.parent;
 				if( parent == null )

--- a/domkit/Properties.hx
+++ b/domkit/Properties.hx
@@ -25,6 +25,7 @@ class Properties<T:Model<T>> {
 	public var hover(default,set) : Bool = false;
 	public var active(default,set) : Bool = false;
 	public var disabled(default,set) : Bool = false;
+	public var focus(default,set) : Bool = false;
 	public var parent(get,never) : Properties<T>;
 	public var contentRoot(default,null) : Model<T>;
 
@@ -138,6 +139,12 @@ class Properties<T:Model<T>> {
 		if( disabled == b ) return b;
 		needRefresh();
 		return disabled = b;
+	}
+
+	function set_focus(b) {
+		if( focus == b ) return b;
+		needRefresh();
+		return focus = b;
 	}
 
 	function initStyle( p : String, value : Dynamic ) {


### PR DESCRIPTION
Adds `:focus` pseudoclass. This would be useful for heaps' `h2d.TextInput` object and other components. It is also available in standard CSS.