### PR TITLE
Add error on super called after initComponent()

### DIFF
--- a/domkit/Macros.hx
+++ b/domkit/Macros.hx
@@ -506,6 +506,13 @@ class Macros {
 				case FFun(f):
 					function replace( e : Expr ) {
 						switch( e.expr ) {
+						case ECall({ expr: EField({ pos: pos, expr : EConst(CIdent("super")) }, fn) }, _) if( initFunc != "new" ):
+							if (found != null && fn == initFunc)
+								Context.reportError("Calling super." + initFunc + "() after initComponent()", pos);
+						case ECall({ expr : EConst(CIdent("super")), pos: pos }, _) if ( initFunc == "new" ):
+							if (found != null)
+								Context.reportError("Calling super() after initComponent()", pos);
+
 						case ECall({ expr : EConst(CIdent("initComponent")) },[]):
 							// we don't generate an override initComponent method
 							// because it needs to access constructor variables - so we directly inline it


### PR DESCRIPTION
Having the parent class' initComponent() call after the child's will give only the parent class' properties.

(This is somewhat tedious to investigate if you don't immediately see the initComponent() in the wrong place)