### PR TITLE
Fix elements with conditions not resetting their values on init

### DIFF
--- a/domkit/Macros.hx
+++ b/domkit/Macros.hx
@@ -346,6 +346,7 @@ class Macros {
 							pos : makePos(pos, a.pmin, a.pmax),
 							kind : FVar(ct),
 						});
+						data.inits.push(macro this.$field = null);
 					}
 				}
 			for( e in aexprs )


### PR DESCRIPTION
This used to cause issues with code like this

```
static var SRC = <comp>
	<flow id="test" if(complexCondition)/>
</comp>

override function init() {
	super.init();
	initComponent();
	if (test != null) {
		// code that assumes complexCondition is true
	}
	bind(function() {
		if (!complexCondition)
			rebuild();
	});
}
```
