### PR TITLE
Fix enum @:p using lowercase fields rather than css-case

### DIFF
--- a/domkit/CssValue.hx
+++ b/domkit/CssValue.hx
@@ -200,9 +200,10 @@ class ValueParser {
 		var h = new Map();
 		var all = [];
 		for( v in e.createAll() ) {
-			var id = v.getName().toLowerCase();
+			var id = CssParser.haxeToCss(v.getName());
 			h.set(id, v);
 			all.push(id);
+			h.set(v.getName().toLowerCase(), v);
 		}
 		var choices = all.join("|");
 		return function( v : CssValue ) {

--- a/domkit/MetaComponent.hx
+++ b/domkit/MetaComponent.hx
@@ -335,13 +335,14 @@ class MetaComponent extends Component<Dynamic,Dynamic> {
 			default:
 			}
 		case TEnum(en,_):
-			var idents = [for( n in en.get().names ) n.toLowerCase()];
+			var idents = [for( n in en.get().names ) CssParser.haxeToCss(n)];
+			var fallback = [for( n in en.get().names ) n.toLowerCase()];
 			var enexpr = makeTypeExpr(en.get(), pos);
 			return {
 				expr : macro parser.makeEnumParser($enexpr),
 				value : function(css:CssValue) {
 					return switch( css ) {
-					case VIdent(i) if( idents.indexOf(i) >= 0 ): true;
+					case VIdent(i) if( idents.indexOf(i) >= 0 || fallback.indexOf(i) >= 0 ): true;
 					case VIdent(v): parser.invalidProp(v+" should be "+idents.join("|"));
 					default: parser.invalidProp();
 					}


### PR DESCRIPTION
For example on an h2d.Text you can now use `text-align: multiline-center` (`multilinecenter` is still supported)