### PR TITLE
Add CssStyle.clear()

### DIFF
--- a/domkit/CssStyle.hx
+++ b/domkit/CssStyle.hx
@@ -235,6 +235,10 @@ class CssData {
 		needsInit = true;
 	}
 
+	public function clear() {
+		rules.resize(0);
+		needsInit = true;
+	}
 }
 
 @:access(domkit.Properties)
@@ -599,6 +603,9 @@ class CssStyle {
 
 	public function add( sheet : CssParser.CssSheet ) {
 		data.add(sheet);
+	}
+	public function clear() {
+		data.clear();
 	}
 
 	public static function ruleMatch( c : CssParser.CssClass, e : Properties<Dynamic> ) {

--- a/domkit/MetaComponent.hx
+++ b/domkit/MetaComponent.hx
@@ -19,6 +19,7 @@ enum ParserMode {
 
 class MetaComponent extends Component<Dynamic,Dynamic> {
 
+	#if macro
 	public var baseType : ComplexType;
 	public var parserType : ComplexType;
 	public var setExprs : Map<String, Expr> = new Map();
@@ -468,4 +469,5 @@ class MetaComponent extends Component<Dynamic,Dynamic> {
 		return macro : domkit.$name;
 	}
 
+	#end
 }


### PR DESCRIPTION
Call CssStyle.clear() before doing load() on style sheets that were already loaded once, to avoid duplicate rules/memory leaks