### PR TITLE
Rework components cache

### DIFF
--- a/domkit/Macros.hx
+++ b/domkit/Macros.hx
@@ -621,13 +621,14 @@ class Macros {
 			try {
 				var m = new MetaComponent(Context.getLocalType(), fields);
 				if( componentsType == null ) componentsType = m.baseType;
-				if (!COMPONENTS.exists(m.name) || !m.isRuntimeComponentAlive())
+				if (!COMPONENTS.exists(m.name) || !m.isRuntimeComponentAlive()) {
 					Context.defineType(m.buildRuntimeComponent(componentsType,fields));
+					COMPONENTS.set(m.name, m);
+				}
 				var t = m.getRuntimeComponentType();
 				fields.push((macro class {
 					static var ref : $t = null;
 				}).fields[0]);
-				COMPONENTS.set(m.name, m);
 				foundComp = m.name;
 			} catch( e : MetaComponent.MetaError ) {
 				Context.error(e.message, e.position);

--- a/domkit/Macros.hx
+++ b/domkit/Macros.hx
@@ -23,7 +23,6 @@ class Macros {
 	@:persistent static var componentsType : ComplexType;
 	@:persistent static var preload : Array<String> = [];
 	@:persistent public static var defaultParserPath : String = null;
-	static var RESOLVED_COMPONENTS = new Map();
 
 	public static dynamic function processMacro( id : String, args : Null<Array<haxe.macro.Expr>>, pos : haxe.macro.Expr.Position ) : MarkupParser.Markup {
 		return null;
@@ -67,20 +66,21 @@ class Macros {
 	}
 
 	static function loadComponent( name : String, pmin : Int, pmax : Int ) {
-		var c = RESOLVED_COMPONENTS.get(name);
+		var c = COMPONENTS.get(name);
 		if( c != null ) {
-			if( c.path != null ) Context.getType(c.path);
-			return c.c;
+			// Make sure the built component is still available
+			if (c.isRuntimeComponentAlive()) return c;
+			// ... or forget about it
+			else COMPONENTS.remove(name);
 		}
+
 		var lastError = null;
 		var uname = MetaComponent.componentNameToClass(name);
 		for( p in componentsSearchPath ) {
 			var path = p.split("$").join(uname);
 			var t = try Context.getType(path) catch( e : Dynamic ) continue;
 			switch( t.follow() ) {
-			case TInst(c,_):
-				if( p == "$" ) path = c.toString(); // if we found with unqualified name, requalify
-				c.get(); // force build
+			case TInst(c,_): c.get(); // force build
 			default:
 			}
 			var c = COMPONENTS.get(name);
@@ -88,7 +88,6 @@ class Macros {
 				lastError = t;
 				continue;
 			}
-			RESOLVED_COMPONENTS.set(name, { c : c, path : path });
 			return c;
 		}
 		if( lastError != null )
@@ -622,14 +621,14 @@ class Macros {
 			try {
 				var m = new MetaComponent(Context.getLocalType(), fields);
 				if( componentsType == null ) componentsType = m.baseType;
-				Context.defineType(m.buildRuntimeComponent(componentsType,fields));
+				if (!COMPONENTS.exists(m.name) || !m.isRuntimeComponentAlive())
+					Context.defineType(m.buildRuntimeComponent(componentsType,fields));
 				var t = m.getRuntimeComponentType();
 				fields.push((macro class {
 					static var ref : $t = null;
 				}).fields[0]);
 				COMPONENTS.set(m.name, m);
 				foundComp = m.name;
-				RESOLVED_COMPONENTS.set(m.name,{ path : null, c : m }); // allow self resolution in document build
 			} catch( e : MetaComponent.MetaError ) {
 				Context.error(e.message, e.position);
 			}
@@ -646,8 +645,6 @@ class Macros {
 		} else if( isComp && !cl.meta.has(":domkitDecl") ) {
 			buildDocument(cl, '<$foundComp></$foundComp>', cl.pos, fields, foundComp);
 		}
-		if( foundComp != null )
-			RESOLVED_COMPONENTS.remove(foundComp);
 		return fields;
 	}
 

--- a/domkit/MetaComponent.hx
+++ b/domkit/MetaComponent.hx
@@ -469,5 +469,11 @@ class MetaComponent extends Component<Dynamic,Dynamic> {
 		return macro : domkit.$name;
 	}
 
+	public function isRuntimeComponentAlive() {
+		var ct = getRuntimeComponentType();
+		var pos = haxe.macro.Context.currentPos();
+		return try haxe.macro.Context.resolveType(ct, pos) != null catch(_) false;
+	}
+
 	#end
 }


### PR DESCRIPTION
So far I have not been able to isolate the issue that Dune has on Game.hx completion, but only reproduced via a non-server example (see below). I'd need to check in more details what `buildDocument` does in order to make a simple repro of the compilation server issue.

The problem I'm seeing on the original issue is:

Initial compilation:
* Note: no registration for `ui.menu.$`, only `ui.menu.$UI`
* `ui.menu.Screen` enters its `buildObject`, and add itself (temporarily) to `RESOLVED_COMPONENTS`
* `Screen`'s `buildDocument` triggers (indirectly) build of `ui.LoadingScreen.MenuLoadingScreen`, which has `ui.menu.Screen` as parent class.
* Parent class is resolved through `RESOLVED_COMPONENTS`
* `Screen` resumes building, removes its temp entry from `RESOLVED_COMPONENTS`

Recompilation with `Screen` still in cache and `ui.LoadingScreen.MenuLoadingScreen` being rebuilt:
* `ui.LoadingScreen.MenuLoadingScreen` enters its `buildObject`, looks for its parent class
* `Screen`'s temp entry is no longer in `RESOLVED_COMPONENTS` and also cannot be resolved
* `Missing super component registration screen` error

Using `COMPONENTS` directly, by making sure we're not using discarded components, we can skip the `RESOLVED_COMPONENTS` business entirely.

Would still be interesting to double check on different domkit codebases.
```
haxelib git domkit https://github.com/kLabz/domkit fix/missing-comp-registration
```

## Example without server

`Main.hx`
```hx
trace(components2.Comp2);
```

`components1/Comp1.hx`
```hx
package components1;

class Comp1 extends h2d.Flow implements h2d.domkit.Object {
	static var SRC =
		<comp1>
			<text text={"Hello World"}/>
		</comp1>;

	public function new(?parent) {
		super(parent);
		initComponent();
	}

}
```

`components2/Comp2.hx`
```hx
package components2;

class Comp2 extends components1.Comp1 {
	static var SRC =
		<comp2>
			<text text={"Hello World"}/>
		</comp2>;


	public function new(?parent) {
		super(parent);
		initComponent();
	}

}
```

Before: `Missing super component registration comp1`
After: Ok