### PR TITLE
Fix applyStyleRec sometimes applying the same property multiple times

### DIFF
--- a/domkit/CssStyle.hx
+++ b/domkit/CssStyle.hx
@@ -5,6 +5,7 @@ class RuleStyle {
 	public var value : CssValue;
 	public var lastHandler : Component.PropertyHandler<Dynamic,Dynamic>;
 	public var lastValue : Dynamic;
+	public var next : RuleStyle;
 	public function new(p,value) {
 		this.p = p;
 		this.value = value;
@@ -29,7 +30,6 @@ class Rule {
 	public var cl : CssParser.CssClass;
 	public var style : Array<RuleStyle>;
 	public var transitions : Array<RuleTransition>;
-	public var next : Rule;
 	public function new() {
 	}
 }
@@ -418,11 +418,16 @@ class CssStyle {
 			for( r in rules ) {
 				if( !ruleMatch(r.cl,e) ) continue;
 				var match = false;
-				for( p in r.style )
+				var i = r.style.length - 1;
+				while( i >= 0 ) {
+					var p = r.style[i--];
 					if( p.p.tag != tag ) {
 						p.p.tag = tag;
 						match = true;
+						p.next = head;
+						head = p;
 					}
+				}
 				if( r.transitions != null ) {
 					for( t in r.transitions ) {
 						if( t.p.transTag != tag ) {
@@ -431,10 +436,6 @@ class CssStyle {
 							transHead = t;
 						}
 					}
-				}
-				if( match ) {
-					r.next = head;
-					head = r;
 				}
 			}
 
@@ -474,9 +475,8 @@ class CssStyle {
 				}
 			}
 			// apply new properties
-			var r = head;
-			while( r != null ) {
-				for( p in r.style ) {
+			var p = head;
+			while( p != null ) {
 					var pr = p.p;
 					var h = e.component.getHandler(pr);
 					if( h == null ) {
@@ -523,10 +523,9 @@ class CssStyle {
 							e.currentValues[e.currentSet.indexOf(pr)] = p.value;
 						}
 					}
-				}
-				var n = r.next;
-				r.next = null;
-				r = n;
+				var n = p.next;
+				p.next = null;
+				p = n;
 			}
 
 			// cancel transitions that are no longer valid

--- a/domkit/CssStyle.hx
+++ b/domkit/CssStyle.hx
@@ -417,13 +417,11 @@ class CssStyle {
 
 			for( r in rules ) {
 				if( !ruleMatch(r.cl,e) ) continue;
-				var match = false;
 				var i = r.style.length - 1;
 				while( i >= 0 ) {
 					var p = r.style[i--];
 					if( p.p.tag != tag ) {
 						p.p.tag = tag;
-						match = true;
 						p.next = head;
 						head = p;
 					}


### PR DESCRIPTION
This PR makes it so properties are set only once per applyStyle.

Before this, when a property was set twice from the css style, if it was not alone in the css block it would be set twice on every applyStyle.
For exemple pad-focusable here:
```
my-flow {
	base-button {
		pad-focusable: false;
	}
	base-button {
		recursive-propagate: true;
	}
	&.enabled {
		base-button {
			pad-focusable: true;
		}
	}
}
```
^ with the class .enabled, set_padFocusable was called only once (`true`)

```
my-flow {
	base-button {
		pad-focusable: false;
		recursive-propagate: true;
	}
	&.enabled {
		base-button {
			pad-focusable: true;
		}
	}
}
```
^ with the class .enabled, set_padFocusable was called twice (`false` then `true`)

This may have some side effects for code that assumed the setter was called twice, for example where same-frame transitions are concerned.

The question remains as to whether only the highest priority rule should be applied or if every rule should be applied every time in increasing priority order.