### PR TITLE
Add position to RuleStyle, and add currentRuleStyles to Properties (show line number on h2d domkit inspector)

### DIFF
--- a/domkit/CssParser.hx
+++ b/domkit/CssParser.hx
@@ -118,7 +118,7 @@ typedef CssSheet = Array<CssSheetElement>;
 
 typedef CssSheetElement = {
 	var classes : Array<CssClass>;
-	var style : Array<{ p : Property, value : CssValue, pmin : Int, vmin : Int, pmax : Int }>;
+	var style : Array<{ p : Property, value : CssValue, pmin : Int, vmin : Int, pmax : Int, file: String }>;
 	var ?transitions : Array<Transition>;
 	var ?subRules : CssSheet;
  }
@@ -178,6 +178,7 @@ class CssParser {
 
 	var css : String;
 	var pos : Int;
+	var file: String;
 	var tokenStart : Int;
 	var valueStart : Int;
 
@@ -261,9 +262,10 @@ class CssParser {
 		return false;
 	}
 
-	public function parse( css : String ) {
+	public function parse( css : String, file : String ) {
 		this.css = css;
 		pos = 0;
+		this.file = file;
 		tokens = [];
 		warnings = [];
 		return parseStyle(null, TEof);
@@ -403,7 +405,7 @@ class CssParser {
 				} else
 					warnings.push({ pmin : start, pmax : pos, msg : "Unknown property "+name });
 			} else
-				rules.push({ p : p, value : value, pmin : start, vmin : valueStart, pmax : pos });
+				rules.push({ p : p, value : value, pmin : start, vmin : valueStart, pmax : pos, file: file });
 			if( isToken(eof) )
 				break;
 			expect(TSemicolon);
@@ -411,9 +413,10 @@ class CssParser {
 		return { classes : classes, style : rules, transitions : trans, subRules : subRules };
 	}
 
-	public function parseSheet( css : String ) : CssSheet {
+	public function parseSheet( css : String, file : String ) : CssSheet {
 		this.css = css;
 		pos = 0;
+		this.file = file;
 		tokens = [];
 		warnings = [];
 		warnedComponents = new Map();
@@ -471,9 +474,10 @@ class CssParser {
 		return [elt];
 	}
 
-	public function parseClasses( css : String, ?hasParent ) {
+	public function parseClasses( css : String, ?hasParent, file : String ) {
 		this.css = css;
 		pos = 0;
+		this.file = file;
 		tokens = [];
 		var c = readClasses(hasParent);
 		expect(TEof);

--- a/domkit/CssParser.hx
+++ b/domkit/CssParser.hx
@@ -262,7 +262,7 @@ class CssParser {
 		return false;
 	}
 
-	public function parse( css : String, file : String ) {
+	public function parse( css : String, ?file : String ) {
 		this.css = css;
 		pos = 0;
 		this.file = file;
@@ -413,7 +413,7 @@ class CssParser {
 		return { classes : classes, style : rules, transitions : trans, subRules : subRules };
 	}
 
-	public function parseSheet( css : String, file : String ) : CssSheet {
+	public function parseSheet( css : String, ?file : String ) : CssSheet {
 		this.css = css;
 		pos = 0;
 		this.file = file;
@@ -474,7 +474,7 @@ class CssParser {
 		return [elt];
 	}
 
-	public function parseClasses( css : String, ?hasParent, file : String ) {
+	public function parseClasses( css : String, ?hasParent, ?file : String ) {
 		this.css = css;
 		pos = 0;
 		this.file = file;

--- a/domkit/CssStyle.hx
+++ b/domkit/CssStyle.hx
@@ -6,9 +6,11 @@ class RuleStyle {
 	public var lastHandler : Component.PropertyHandler<Dynamic,Dynamic>;
 	public var lastValue : Dynamic;
 	public var next : RuleStyle;
-	public function new(p,value) {
+	public var pos : { pmin : Int, vmin : Int, pmax : Int };
+	public function new(p, value, ?pos) {
 		this.p = p;
 		this.value = value;
+		this.pos = pos;
 	}
 }
 
@@ -207,9 +209,9 @@ class CssData {
 					switch( s.value ) {
 					case VLabel("important", val):
 						if( important == null ) important = [];
-						important.push(new RuleStyle(s.p,val));
+						important.push(new RuleStyle(s.p, val, s));
 					default:
-						rule.style.push(new RuleStyle(s.p,s.value));
+						rule.style.push(new RuleStyle(s.p, s.value, s));
 					}
 				rule.priority = priority;
 				if( r.transitions != null ) {
@@ -462,6 +464,7 @@ class CssStyle {
 					changed = true;
 					e.currentSet.remove(p);
 					if( e.currentValues != null ) e.currentValues.splice(i+1,1);
+					if( e.currentRuleStyles != null ) e.currentRuleStyles.splice(i+1,1);
 					var h = e.component.getHandler(p);
 					if( p.transTag == tag ) {
 						p.transTag = ntag;
@@ -515,14 +518,16 @@ class CssStyle {
 				if( pr.tag != ntag ) {
 					if( Properties.KEEP_VALUES ) {
 						e.initCurrentValues();
-						e.currentValues.push(p.value);
+						e.currentValues.push(null);
+						e.currentRuleStyles.push(p);
 					}
 					e.currentSet.push(pr);
 					pr.tag = ntag;
 				} else {
 					if( Properties.KEEP_VALUES ) {
 						e.initCurrentValues();
-						e.currentValues[e.currentSet.indexOf(pr)] = p.value;
+						e.currentValues[e.currentSet.indexOf(pr)] = null;
+						e.currentRuleStyles[e.currentSet.indexOf(pr)] = p;
 					}
 				}
 				p = next;

--- a/domkit/CssStyle.hx
+++ b/domkit/CssStyle.hx
@@ -385,14 +385,7 @@ class CssStyle {
 			componentsBits = prevBits;
 	}
 
-	var wasHover = false;
 	function applyStyleRec( e : Properties<Dynamic>, force : Bool, rules : Array<Rule> ) {
-		if (Std.isOfType(e.obj?.parent, ui.hud.AlertsUI.AlertButton) && e.hasClass("alert-cont")) {
-			if (wasHover != e.obj.parent.dom.hover) {
-				trace("Parent hover changed");
-				wasHover = e.obj.parent.dom.hover;
-			}
-		}
 
 		var prev = -1;
 		if( useSmartCache ) {

--- a/domkit/CssStyle.hx
+++ b/domkit/CssStyle.hx
@@ -6,7 +6,7 @@ class RuleStyle {
 	public var lastHandler : Component.PropertyHandler<Dynamic,Dynamic>;
 	public var lastValue : Dynamic;
 	public var next : RuleStyle;
-	public var pos : { pmin : Int, vmin : Int, pmax : Int };
+	public var pos : { pmin : Int, vmin : Int, pmax : Int, file: String };
 	public function new(p, value, ?pos) {
 		this.p = p;
 		this.value = value;
@@ -385,7 +385,14 @@ class CssStyle {
 			componentsBits = prevBits;
 	}
 
+	var wasHover = false;
 	function applyStyleRec( e : Properties<Dynamic>, force : Bool, rules : Array<Rule> ) {
+		if (Std.isOfType(e.obj?.parent, ui.hud.AlertsUI.AlertButton) && e.hasClass("alert-cont")) {
+			if (wasHover != e.obj.parent.dom.hover) {
+				trace("Parent hover changed");
+				wasHover = e.obj.parent.dom.hover;
+			}
+		}
 
 		var prev = -1;
 		if( useSmartCache ) {

--- a/domkit/CssStyle.hx
+++ b/domkit/CssStyle.hx
@@ -518,7 +518,7 @@ class CssStyle {
 				if( pr.tag != ntag ) {
 					if( Properties.KEEP_VALUES ) {
 						e.initCurrentValues();
-						e.currentValues.push(null);
+						e.currentValues.push(p.value);
 						e.currentRuleStyles.push(p);
 					}
 					e.currentSet.push(pr);
@@ -526,8 +526,9 @@ class CssStyle {
 				} else {
 					if( Properties.KEEP_VALUES ) {
 						e.initCurrentValues();
-						e.currentValues[e.currentSet.indexOf(pr)] = null;
-						e.currentRuleStyles[e.currentSet.indexOf(pr)] = p;
+						var idx = e.currentSet.indexOf(pr);
+						e.currentValues[idx] = p.value;
+						e.currentRuleStyles[idx] = p;
 					}
 				}
 				p = next;

--- a/domkit/Macros.hx
+++ b/domkit/Macros.hx
@@ -46,7 +46,7 @@ class Macros {
 		}
 		try {
 			var parser = new CssParser();
-			var rules = parser.parseSheet(content);
+			var rules = parser.parseSheet(content, file);
 			var components : Array<Component<Dynamic,Dynamic>> = [for( c in COMPONENTS ) c];
 			inline function height(c:Component<Dynamic,Dynamic>) {
 				var h = 0;

--- a/domkit/Properties.hx
+++ b/domkit/Properties.hx
@@ -295,8 +295,9 @@ class Properties<T:Model<T>> {
 					found = true;
 					if( KEEP_VALUES ) {
 						initCurrentValues();
-						currentValues[currentSet.indexOf(p)] = value;
-						currentRuleStyles[currentSet.indexOf(p)] = null;
+						var idx = currentSet.indexOf(p);
+						currentValues[idx] = value;
+						currentRuleStyles[idx] = null;
 					}
 					break;
 				}

--- a/domkit/Properties.hx
+++ b/domkit/Properties.hx
@@ -33,6 +33,7 @@ class Properties<T:Model<T>> {
 	var style : Array<{ p : Property, value : Any }> = [];
 	var currentSet : Array<Property> = [];
 	var currentValues : Array<CssValue>; // only for inspector
+	var currentRuleStyles : Array<CssStyle.RuleStyle>; // only for inspector
 	var transitionValues : Map<Int,Dynamic>;
 	var needStyleRefresh : Bool = true;
 	var firstInit : Bool = true;
@@ -295,6 +296,7 @@ class Properties<T:Model<T>> {
 					if( KEEP_VALUES ) {
 						initCurrentValues();
 						currentValues[currentSet.indexOf(p)] = value;
+						currentRuleStyles[currentSet.indexOf(p)] = null;
 					}
 					break;
 				}
@@ -302,6 +304,7 @@ class Properties<T:Model<T>> {
 				if( KEEP_VALUES ) {
 					initCurrentValues();
 					currentValues.push(value);
+					currentRuleStyles.push(null);
 				}
 				currentSet.push(p);
 			}
@@ -317,6 +320,8 @@ class Properties<T:Model<T>> {
 	function initCurrentValues() {
 		if( currentValues == null )
 			currentValues = [for( s in currentSet ) null];
+		if( currentRuleStyles == null )
+			currentRuleStyles = [for( s in currentSet ) null];
 	}
 
 	static var pclass = Property.get("class");


### PR DESCRIPTION
This makes it so the h2d domkit inspector can have access to the source position of css sheet elements.
![image](https://github.com/HeapsIO/domkit/assets/22801009/b8f0c7b0-ce32-48a2-bd65-0d82b3b3e39c)

My main concerns with this PR are:
- currentRuleStyles is redundant with currentValues, but I couldn't think of a way to combine them without adding allocations on `Properties.setAttribute()`