### PR TITLE
Add Properties.ignoreParentChange

### DIFF
--- a/domkit/Properties.hx
+++ b/domkit/Properties.hx
@@ -65,7 +65,10 @@ class Properties<T:Model<T>> {
 		return classes.indexOf(new Identifier(name)) >= 0;
 	}
 
+	public var ignoreParentChange = false;
 	public function onParentChanged() {
+		if (ignoreParentChange)
+			return;
 		var p = parent;
 		if( p == null )
 			dirty = new DirtyRef();


### PR DESCRIPTION
This allows reordering objects without changing the parent without triggering an applyStyle every time.

For example:
```
obj.dom.ignoreParentChange = true;
obj.parent.addChildAt(obj, newPos);
obj.dom.ignoreParentChange = false;
```

I initialy wanted to edit `h2d.Object.addChildAt` into something like
`if( s.dom != null && prevParent != this ) s.dom.onParentChanged();`

But then that could break the `first-child`, `last-child`, `odd` and `even` pseudo classes.

and then I realized that these pseudo classes are *already broken* since other children would also have changed position