### PR TITLE
Allow remapping component names in init macros

### DIFF
--- a/domkit/Macros.hx
+++ b/domkit/Macros.hx
@@ -19,6 +19,7 @@ class Macros {
 	#if macro
 
 	@:persistent static var COMPONENTS = new Map<String, domkit.MetaComponent>();
+	@:persistent static var COMPONENTS_REMAP = new Map<String, String>();
 	@:persistent static var componentsSearchPath : Array<String> = ["h2d.domkit.BaseComponents.$Comp"];
 	@:persistent static var componentsType : ComplexType;
 	@:persistent static var preload : Array<String> = [];

--- a/domkit/MetaComponent.hx
+++ b/domkit/MetaComponent.hx
@@ -479,12 +479,22 @@ class MetaComponent extends Component<Dynamic,Dynamic> {
 
 	function getCompName( c : ClassType, opt = false ) {
 		var name = c.meta.extract(":uiComp")[0];
-		if( name == null ) return c.meta.has(":uiNoComponent") || (opt && c.pack[0] == "h2d") ? null : CssParser.haxeToCss(c.name);
-		if( name.params.length == 0 ) error("Invalid :uiComp", name.pos);
-		return switch( name.params[0].expr ) {
-		case EConst(CString(name)): name;
-		default: error("Invalid :uiComp", name.pos);
+		var ret = null;
+		if( name == null ) {
+			var noComp = c.meta.has(":uiNoComponent") || (opt && c.pack[0] == "h2d");
+			if (!noComp)
+				ret = CssParser.haxeToCss(c.name);
+		} else {
+			if( name.params.length == 0 ) error("Invalid :uiComp", name.pos);
+			ret = switch( name.params[0].expr ) {
+				case EConst(CString(name)): name;
+				default: error("Invalid :uiComp", name.pos);
+			}
 		}
+		@:privateAccess if (ret != null && Macros.COMPONENTS_REMAP.exists(ret)) {
+			ret = Macros.COMPONENTS_REMAP.get(ret);
+		}
+		return ret;
 	}
 
 	function error( msg : String, pos : Position ) : Dynamic {


### PR DESCRIPTION
Note that this changes `MetaComponent.getCompName` rather than `Macros.loadComponent`.

The persistent static variable is in Macros next to the other persistents, but it's used only in MetaComponent, should I move it to MetaComponent?