### PR TITLE
Avoid generating stuff with positions like cl.pos

### DIFF
--- a/domkit/Macros.hx
+++ b/domkit/Macros.hx
@@ -478,7 +478,7 @@ class Macros {
 			}
 
 		var inits = [];
-		var initExpr = buildComponentsInit(root, { fields : fields, declaredIds : new Map(), inits : inits, hasContent : false, useThis: true}, pos, true);
+		var initExpr = buildComponentsInit(root, { fields : fields, declaredIds : new Map(), inits : inits, hasContent : false, useThis: true}, Context.currentPos(), true);
 		if( inits.length > 0 ) {
 			inits.push({ expr : initExpr.expr, pos : initExpr.pos });
 			initExpr.expr = EBlock(inits);
@@ -555,10 +555,10 @@ class Macros {
 					var ct : ComplexType = TAnonymous([for( a in f.args ) {
 						name : a.name,
 						kind : FVar(a.type,a.value),
-						pos : cl.pos,
-						meta : a.opt ? [{name:":optional",pos:cl.pos}] : null }
+						pos : Context.currentPos(),
+						meta : a.opt ? [{name:":optional",pos:Context.currentPos()}] : null }
 					]);
-					cl.meta.add(":domkitInitArgs",[macro ($i{initFunc} : $ct)],cl.pos);
+					cl.meta.add(":domkitInitArgs",[macro ($i{initFunc} : $ct)],Context.currentPos());
 					if( found == null && !Context.defined("display") )
 						Context.error("Missing initComponent() call", f.expr.pos);
 					break;
@@ -569,7 +569,7 @@ class Macros {
 			return;
 		if( initArgs == null ) {
 			if( initFunc == "new" )
-				initArgs = [{ name : "parent", kind : FVar(componentsType), meta :  [{name:":optional",pos:cl.pos}], pos : cl.pos }];
+				initArgs = [{ name : "parent", kind : FVar(componentsType), meta :  [{name:":optional",pos:Context.currentPos()}], pos : Context.currentPos() }];
 			else {
 				Context.error("Missing function "+initFunc, Context.currentPos());
 				return;
@@ -578,7 +578,7 @@ class Macros {
 		var anames = [for( a in initArgs ) macro $i{a.name}];
 		fields.push({
 			name : initFunc,
-			pos : cl.pos,
+			pos : Context.currentPos(),
 			kind : FFun({
 				ret : null,
 				args : [for( a in initArgs) {

--- a/domkit/Macros.hx
+++ b/domkit/Macros.hx
@@ -468,6 +468,7 @@ class Macros {
 
 	static function buildDocument( cl : haxe.macro.Type.ClassType, str : String, pos : Position, fields : Array<Field>, rootName : String ) {
 		var p = new MarkupParser();
+		var currentPos = Context.currentPos();
 		var pinf = Context.getPosInfos(pos);
 		var root = p.parse(str,pinf.file,pinf.min).children[0];
 
@@ -478,7 +479,7 @@ class Macros {
 			}
 
 		var inits = [];
-		var initExpr = buildComponentsInit(root, { fields : fields, declaredIds : new Map(), inits : inits, hasContent : false, useThis: true}, Context.currentPos(), true);
+		var initExpr = buildComponentsInit(root, { fields : fields, declaredIds : new Map(), inits : inits, hasContent : false, useThis: true}, currentPos, true);
 		if( inits.length > 0 ) {
 			inits.push({ expr : initExpr.expr, pos : initExpr.pos });
 			initExpr.expr = EBlock(inits);
@@ -555,10 +556,10 @@ class Macros {
 					var ct : ComplexType = TAnonymous([for( a in f.args ) {
 						name : a.name,
 						kind : FVar(a.type,a.value),
-						pos : Context.currentPos(),
-						meta : a.opt ? [{name:":optional",pos:Context.currentPos()}] : null }
+						pos : currentPos,
+						meta : a.opt ? [{name:":optional",pos:currentPos}] : null }
 					]);
-					cl.meta.add(":domkitInitArgs",[macro ($i{initFunc} : $ct)],Context.currentPos());
+					cl.meta.add(":domkitInitArgs",[macro ($i{initFunc} : $ct)],currentPos);
 					if( found == null && !Context.defined("display") )
 						Context.error("Missing initComponent() call", f.expr.pos);
 					break;
@@ -569,16 +570,16 @@ class Macros {
 			return;
 		if( initArgs == null ) {
 			if( initFunc == "new" )
-				initArgs = [{ name : "parent", kind : FVar(componentsType), meta :  [{name:":optional",pos:Context.currentPos()}], pos : Context.currentPos() }];
+				initArgs = [{ name : "parent", kind : FVar(componentsType), meta :  [{name:":optional",pos:currentPos}], pos : currentPos }];
 			else {
-				Context.error("Missing function "+initFunc, Context.currentPos());
+				Context.error("Missing function "+initFunc, currentPos);
 				return;
 			}
 		}
 		var anames = [for( a in initArgs ) macro $i{a.name}];
 		fields.push({
 			name : initFunc,
-			pos : Context.currentPos(),
+			pos : currentPos,
 			kind : FFun({
 				ret : null,
 				args : [for( a in initArgs) {

--- a/domkit/Macros.hx
+++ b/domkit/Macros.hx
@@ -466,9 +466,14 @@ class Macros {
 		return false;
 	}
 
-	static function buildDocument( cl : haxe.macro.Type.ClassType, str : String, pos : Position, fields : Array<Field>, rootName : String ) {
+	static function buildDocument( cl : haxe.macro.Type.ClassType, str : String, pos : Null<Position>, fields : Array<Field>, rootName : String ) {
+		var currentPos = pos;
+		if( pos == null ) {
+			pos = cl.pos;
+			currentPos = Context.currentPos();
+		}
+
 		var p = new MarkupParser();
-		var currentPos = Context.currentPos();
 		var pinf = Context.getPosInfos(pos);
 		var root = p.parse(str,pinf.file,pinf.min).children[0];
 
@@ -654,7 +659,7 @@ class Macros {
 			}
 			fields.remove(hasDocument.f);
 		} else if( isComp && !cl.meta.has(":domkitDecl") ) {
-			buildDocument(cl, '<$foundComp></$foundComp>', cl.pos, fields, foundComp);
+			buildDocument(cl, '<$foundComp></$foundComp>', null, fields, foundComp);
 		}
 		return fields;
 	}


### PR DESCRIPTION
Using the class position for generated fields / expressions messes up display request (especially completion, which can then easily break) on that class.