### PR TITLE
Fix positions in external files

### DIFF
--- a/domkit/MarkupParser.hx
+++ b/domkit/MarkupParser.hx
@@ -116,6 +116,8 @@ class MarkupParser {
 		#if macro
 		var e = try {
 			var pos = haxe.macro.Context.makePosition({ min : filePos + start, max : filePos + start + v.length, file : fileName });
+			// Make sure Haxe lexer knows about that file (required to make positions behave on external domkit files)
+			haxe.macro.PositionTools.toLocation(pos);
 			haxe.macro.Context.parseInlineString(v,pos);
 		} catch( e : Dynamic ) {
 			// fallback for attr={x:v,y:v}


### PR DESCRIPTION
When not doing that, `Context.parseInlineString` will make lexer cache an entry for that file with `v` on first call, which will have wrong newline informations because the file won't be parsed entirely for newlines.

Alternative would be to add a new function in Haxe compiler that would do pretty much the same as `PositionTools.toLocation` is doing here: make sure `Lexer.resolve_pos file` is called.