### PR TITLE
Infer type on Bool @:p vars

### DIFF
--- a/domkit/MetaComponent.hx
+++ b/domkit/MetaComponent.hx
@@ -214,6 +214,7 @@ class MetaComponent extends Component<Dynamic,Dynamic> {
 				case CInt(_): t = macro : Int;
 				case CFloat(_): t = macro : Float;
 				case CString(_): t = macro : String;
+				case CIdent("true" | "false"): t = macro : Bool;
 				default:
 				}
 			default:


### PR DESCRIPTION
So that `@:p var myBool = true;` doesn't raise a "Type required" error on compilation