### PR TITLE
Allow using enum abstract fields' base format on @:p variables

### DIFF
--- a/domkit/MetaComponent.hx
+++ b/domkit/MetaComponent.hx
@@ -379,7 +379,7 @@ class MetaComponent extends Component<Dynamic,Dynamic> {
 										return idx;
 									}
 									switch( css ) {
-										case VIdent(i), VString(i):
+										case VIdent(i):
 											var idx = getIndex(i);
 											if( idx < 0 )
 												return $invalidEnum;

--- a/domkit/MetaComponent.hx
+++ b/domkit/MetaComponent.hx
@@ -368,15 +368,18 @@ class MetaComponent extends Component<Dynamic,Dynamic> {
 								expr: macro {
 									#if (haxe_ver >= 4.3) static #end var all = $a{nameExprs};
 									#if (haxe_ver >= 4.3) static #end var idents = $v{idents};
+									#if (haxe_ver >= 4.3) static #end var names = $v{names};
 									#if (haxe_ver >= 4.3) static #end var fallback = $v{fallback};
 									inline function getIndex(str: String) {
 										var idx = idents.indexOf(str);
+										if( idx < 0 )
+											idx = names.indexOf(str);
 										if( idx < 0 )
 											idx = fallback.indexOf(str);
 										return idx;
 									}
 									switch( css ) {
-										case VIdent(i):
+										case VIdent(i), VString(i):
 											var idx = getIndex(i);
 											if( idx < 0 )
 												return $invalidEnum;


### PR DESCRIPTION
Allows string values and and uppercases from css for enum abstract