### PR TITLE
Fix expression-based class attribute overriding previous classes

### DIFF
--- a/domkit/Interp.hx
+++ b/domkit/Interp.hx
@@ -678,9 +678,9 @@ class Interp {
 				case Code(e):
 					var v : Dynamic = try eval(e,compClass) catch( _ : hscript.Expr.Error ) eval("{"+e+"}",{pmin:compClass.pmin-1,pmax:compClass.pmax-1});
 					if( v is String )
-						dom.setClasses(v);
+						dom.appendClasses(v);
 					else
-						dom.setClasses(null, v);
+						dom.appendClasses(null, v);
 				default:
 					throw "assert";
 				}

--- a/domkit/Macros.hx
+++ b/domkit/Macros.hx
@@ -332,7 +332,7 @@ class Macros {
 					}
 					if( eset == null ) {
 						if( p.name == "class" )
-							aexprs.push(macro @:pos(e.pos) tmp.setClasses($e));
+							aexprs.push(macro @:pos(e.pos) tmp.appendClasses($e));
 						else
 							error("Unknown property "+comp.name+"."+p.name, attr.vmin, attr.pmax);
 					} else {

--- a/domkit/Properties.hx
+++ b/domkit/Properties.hx
@@ -222,6 +222,34 @@ class Properties<T:Model<T>> {
 		if( !sameClasses(classes,prevClasses) )
 			needRefresh();
 	}
+	public function appendClasses( ?classStr : String, ?classObj : Dynamic<Bool> ) {
+		var cl;
+		if( classStr != null )
+			cl = classStr.split(" ");
+		else if( classObj != null ) {
+			cl = [];
+			for( f in Reflect.fields(classObj) )
+				if( Reflect.field(classObj,f) )
+					cl.push(f.split("_").join("-"));
+		} else
+			cl = [];
+
+		var prevClasses = classes == null ? null : classes.copy();
+		for( c in cl ) {
+			var c = StringTools.trim(c);
+			if( c.length == 0 ) continue;
+			var c = new Identifier(c);
+			if( classes == null )
+				classes = [c];
+			else if( classes.indexOf(c) < 0 ) {
+				classes.push(c);
+			}
+		}
+		if( classes != null && classes.length == 0 )
+			classes = null;
+		if( !sameClasses(classes,prevClasses) )
+			needRefresh();
+	}
 
 	static inline function sameClasses( cl1 : Array<Identifier>, cl2 : Array<Identifier> ) {
 		if( (cl1 == null ? 0 : cl1.length) != (cl2 == null ? 0 : cl2.length) )


### PR DESCRIPTION
This makes it so if class A does 

```
initComponent();
dom.addClass("test-1")
```

and class B does
```
<a class={"test-" + 2}/>
```
The `a` will correctly end up with both `.test-1` and `.test-2`

This was already fixed for RawValue class properties in e91d55ac7bb



