### PR TITLE
Fix abstract parser error

### DIFF
--- a/domkit/MetaComponent.hx
+++ b/domkit/MetaComponent.hx
@@ -387,7 +387,7 @@ class MetaComponent extends Component<Dynamic,Dynamic> {
 						};
 						parserDependencies.set(fname, parserField);
 					}
-					return {
+					var p = {
 						expr: (macro $i{fname}),
 						value : function(css:CssValue) {
 							return switch( css ) {
@@ -398,6 +398,16 @@ class MetaComponent extends Component<Dynamic,Dynamic> {
 						},
 						def : null,
 					};
+					switch( mode ) {
+					case PNone:
+						p.expr = macro parser.parseNone.bind(${p.expr});
+						p.value = parser.parseNone.bind(p.value);
+					case PAuto:
+						p.expr = macro parser.parseAuto.bind(${p.expr});
+						p.value = parser.parseAuto.bind(p.value);
+					case PCustom:
+					}
+					return p;
 				}
 			}
 		case TInst(c,_):

--- a/domkit/MetaComponent.hx
+++ b/domkit/MetaComponent.hx
@@ -351,8 +351,9 @@ class MetaComponent extends Component<Dynamic,Dynamic> {
 					var fname = "parse" + ab.name;
 
 					var parserField = parserDependencies.get(fname);
+					var errMsg = idents.length > 8 ? " is not part of " + ab.name : " should be "+idents.join("|");
 					if (parserField == null) {
-						var invalidEnum = macro parser.invalidProp(i+" should be "+idents.join("|"));
+						var invalidEnum = macro parser.invalidProp(i + $v{errMsg});
 						parserField = {
 							name: fname,
 							pos: pos,
@@ -391,7 +392,7 @@ class MetaComponent extends Component<Dynamic,Dynamic> {
 						value : function(css:CssValue) {
 							return switch( css ) {
 								case VIdent(i) if( idents.indexOf(i) >= 0 || fallback.indexOf(i) >= 0 ): true;
-								case VIdent(v): parser.invalidProp(v+" should be "+idents.join("|"));
+								case VIdent(v): parser.invalidProp(v + errMsg);
 								default: parser.invalidProp();
 							}
 						},


### PR DESCRIPTION
This PR makes it so parsers on @:abstract enum types:
- Will no longer show excessively long messages when there are more than 8 fields (see image). Now it will show 'value is not part of EnumName' instead
<img width="1919" height="181" alt="image" src="https://github.com/user-attachments/assets/1bf3ad7d-7945-4d07-baf7-92cfdb829ab8" />

- Will allow assigning none or auto when using @:p(none) or @:p(auto), thereby assigning null