### PR TITLE
Reduce applyStyles when adding/removing a child

### DIFF
--- a/domkit/CssStyle.hx
+++ b/domkit/CssStyle.hx
@@ -438,6 +438,8 @@ class CssStyle {
 
 			for( r in rules ) {
 				if( !ruleMatch(r.cl,e) ) continue;
+				if(r.cl.pseudoClasses.has(NeedChildren) && e.parent != null)
+					e.parent.hasNeedChildren = true;
 				var i = r.style.length - 1;
 				while( i >= 0 ) {
 					var p = r.style[i--];
@@ -591,6 +593,8 @@ class CssStyle {
 			// parent style has changed, we need to sync children
 			force = true;
 		}
+		if (force)
+			e.hasNeedChildren = false;
 		var obj : Model<Dynamic> = e.obj;
 		for( c in @:privateAccess obj.getChildren() ) {
 			var c : Model<Dynamic> = c;

--- a/domkit/Properties.hx
+++ b/domkit/Properties.hx
@@ -95,6 +95,7 @@ class Properties<T:Model<T>> {
 	var dirtyPrev : Properties<T>;
 	var dirtyNext : Properties<T>;
 	var depth : Int = 0;
+	var hasNeedChildren = false;
 
 	static var KEEP_VALUES = false;
 
@@ -138,7 +139,7 @@ class Properties<T:Model<T>> {
 		if( p == null ) {
 			dirty = new DirtyList<T>();
 			depth = 0;
-			if( prev != null )
+			if( prev != null && prev.hasNeedChildren)
 				prev.needRefresh(); // can change :first-child etc.
 		} else {
 			dirty = p.dirty;


### PR DESCRIPTION
This makes it so `onParentChanged()` only calls `needRefresh(` on the parent if any of its children have ever had a NeedChildren pseudo class (`:first-child`, `:odd` and such)