### PR TITLE
Fix errors on the Comp constructor taking the entire class as pos

### DIFF
--- a/domkit/MetaComponent.hx
+++ b/domkit/MetaComponent.hx
@@ -29,6 +29,7 @@ class MetaComponent extends Component<Dynamic,Dynamic> {
 	var parser : CssValue.ValueParser;
 	var classType : ClassType;
 	var baseClass : ClassType;
+	var constructorPos : Position;
 	var constructorPath : Array<String>;
 	var constructorArgs : Array<{ type : ComplexType, name : String, opt : Bool }>;
 	var parserDependencies : Map<String, Field> = new Map();
@@ -40,6 +41,7 @@ class MetaComponent extends Component<Dynamic,Dynamic> {
 		}
 		typePath = makeTypePath(classType).join(".");
 
+		constructorPos = classType.pos;
 		var c = classType;
 		var name = getCompName(c);
 		if( name == null ) throw "assert";
@@ -130,6 +132,7 @@ class MetaComponent extends Component<Dynamic,Dynamic> {
 		}
 
 		if( f == null ) return;
+		constructorPos = f.pos;
 
 		switch( f.kind ) {
 		case FFun(f):
@@ -611,7 +614,7 @@ class MetaComponent extends Component<Dynamic,Dynamic> {
 		var newExpr;
 		var cargs = getConstructorArgs();
 		if( cargs != null ) {
-			newExpr = haxe.macro.MacroStringTools.toFieldExpr(constructorPath, classType.pos);
+			newExpr = haxe.macro.MacroStringTools.toFieldExpr(constructorPath, constructorPos);
 			if( cargs.length == 0 )
 				newExpr = macro function(_,parent) return ($newExpr)(parent);
 			else {
@@ -621,7 +624,7 @@ class MetaComponent extends Component<Dynamic,Dynamic> {
 				eargs.push(macro parent);
 				newExpr = macro function(args,parent) return ($newExpr)($a{eargs});
 			}
-			setPosRec(newExpr, classType.pos);
+			setPosRec(newExpr, constructorPos);
 		} else
 			newExpr = macro function(args,parent) throw $v{cname+" cannot be constructed"};
 


### PR DESCRIPTION
At the moment this code yields the error `h2d.Object should be Null<Float> For function argument 'parent'`, but highlights the error on the entire class.
<img width="588" height="319" alt="image" src="https://github.com/user-attachments/assets/c9c756a8-30e8-4bc5-bdea-e5d5be879eaa" />
This PR makes it so it only takes the pos of the constructor
<img width="597" height="312" alt="image" src="https://github.com/user-attachments/assets/9247d7fd-b6ad-4fd2-a993-1cb552a50d1e" />

The actual error is located in the runtime component generated code that does `new ClassB(cast args[0], parent);` because there's a wrong type inference on the constructor arguments. Using `null` on super's optional arguments or explicitly typing `parent` fixes the error.

This PR is just to reduce the amount of highlighted text when there's an error